### PR TITLE
WIP: update buildkit adapters to support hardlink merges.

### DIFF
--- a/daemon/graphdriver/fsdiff.go
+++ b/daemon/graphdriver/fsdiff.go
@@ -4,10 +4,12 @@ import (
 	"io"
 	"time"
 
+	ctdmount "github.com/containerd/containerd/mount"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/ioutils"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -169,4 +171,18 @@ func (gdw *NaiveDiffDriver) DiffSize(id, parent string) (size int64, err error) 
 	defer driver.Put(id)
 
 	return archive.ChangesSize(layerFs.Path(), changes), nil
+}
+
+func (gdw *NaiveDiffDriver) GetDirectMounts(id, mountLabel string) ([]ctdmount.Mount, error) {
+	if gdw, ok := gdw.ProtoDriver.(DirectMountDriver); ok {
+		return gdw.GetDirectMounts(id, mountLabel)
+	}
+	return nil, errors.New("driver does not support GetDirectMounts")
+}
+
+func (gdw *NaiveDiffDriver) PutDirectMounts(id string) error {
+	if gdw, ok := gdw.ProtoDriver.(DirectMountDriver); ok {
+		return gdw.PutDirectMounts(id)
+	}
+	return errors.New("driver does not support PutDirectMounts")
 }


### PR DESCRIPTION
BuildKit's mergeop implementation relies on inspecting mount options in
order to implement the optimization where merged directories are created
using hardlinks from source files instead of copies. This is needed in
the overlay case to ensure that hardlinks are made from underlying
lowerdirs rather than from already mounted overlays.

The main difficulty is that the graphdriver model creates mounts for
callers and then just expects that they bind mount that somewhere, which
is a significant deviation from the containerd model BuildKit uses where
mount options are returned and callers are expected to mount those
themselves.

This update is a quite ugly but solves the problem by bolting on methods
to the relevant graphdriver implementations that enable retrieving mount
options directly instead of having the mounts be made on the callers
behalf.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

